### PR TITLE
Fix typos in JS comments

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -407,9 +407,9 @@ $(function () {
 	});
 	
 	
-	/*
-		Validate Commect Form
-	*/
+        /*
+                Validate Comment Form
+        */
 	
 	$("#comment_form").validate({
 		rules: {
@@ -435,9 +435,9 @@ $(function () {
 	}
 
 
-	/*
-		Tesimonials Carousel
-	*/
+        /*
+                Testimonials Carousel
+        */
 	var revs_slider = $(".revs-carousel.default-revs .owl-carousel");
 
 	revs_slider.owlCarousel({


### PR DESCRIPTION
## Summary
- correct spelling of testimonials carousel comment
- fix typo in comment form validation comment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ef22332b48328b9b848b3f44622ab